### PR TITLE
Demonstrate virtual background freeze

### DIFF
--- a/src/components/VideoProvider/useBackgroundSettings/useBackgroundSettings.ts
+++ b/src/components/VideoProvider/useBackgroundSettings/useBackgroundSettings.ts
@@ -148,6 +148,8 @@ export default function useBackgroundSettings(videoTrack: LocalVideoTrack | unde
       }
       removeProcessor();
       videoTrack.addProcessor(processor);
+      console.log('**** Added processor to video track');
+      console.log(JSON.stringify(videoTrack));
     },
     [videoTrack, removeProcessor]
   );


### PR DESCRIPTION
This PR demonstrates that calling JSON.stringify on a video track containing a virtual background processor results in the browser becoming unresponsive. I think this also likely applies to participants, publications, and perhaps other objects.

To see the bug, enter a room and set a virtual background.
